### PR TITLE
Moved defaultValue from function parameter to core.util.method

### DIFF
--- a/borsh/assembly/deserializer.ts
+++ b/borsh/assembly/deserializer.ts
@@ -9,7 +9,7 @@ export class BorshDeserializer extends Deserializer<ArrayBuffer>{
     this.decoBuffer = new DecodeBuffer(encoded_object)
   }
   
-  _decode_field<T>(_name: string, _defaultValue: T): T {
+  _decode_field<T>(_name: string): T {
     return this.decode<T>()
   }
   

--- a/borsh/assembly/deserializer.ts
+++ b/borsh/assembly/deserializer.ts
@@ -9,7 +9,7 @@ export class BorshDeserializer extends Deserializer<ArrayBuffer>{
     this.decoBuffer = new DecodeBuffer(encoded_object)
   }
   
-  _decode_field<T>(_name: string): T {
+  decode_field<T>(_name: string): T {
     return this.decode<T>()
   }
   

--- a/core/assembly/deserializer.ts
+++ b/core/assembly/deserializer.ts
@@ -11,11 +11,7 @@ export abstract class Deserializer<I> {
   }
 
   // Decode Field
-  abstract _decode_field<T>(name: string): T
-
-  decode_field<T>(name: string): T {
-    return this._decode_field<T>(name);
-  }
+  abstract decode_field<T>(name: string): T
 
   // Boolean
   abstract decode_bool(): bool

--- a/core/assembly/deserializer.ts
+++ b/core/assembly/deserializer.ts
@@ -1,5 +1,4 @@
 import { u128 } from "as-bignum";
-import { defaultValue } from "./utils";
 
 @global
 export abstract class Deserializer<I> {
@@ -12,10 +11,10 @@ export abstract class Deserializer<I> {
   }
 
   // Decode Field
-  abstract _decode_field<T>(name: string, defaultValue: T): T
+  abstract _decode_field<T>(name: string): T
 
-  decode_field<T>(name: string, _defaultValue: T = defaultValue<T>()): T {
-    return this._decode_field(name, _defaultValue);
+  decode_field<T>(name: string): T {
+    return this._decode_field<T>(name);
   }
 
   // Boolean

--- a/json/assembly/deserializer.ts
+++ b/json/assembly/deserializer.ts
@@ -1,4 +1,4 @@
-import { Deserializer, allocObj, WRAP } from "@serial-as/core";
+import { Deserializer, allocObj, WRAP, defaultValue } from "@serial-as/core";
 import { u128, u128Safe } from "as-bignum";
 import * as base64 from "as-base64";
 import { JSON } from "assemblyscript-json";
@@ -33,10 +33,10 @@ export class ValueDeserializer extends Deserializer<JSON.Value>{
     return (<JSON.Arr>this.currentVal);
   }
 
-  _decode_field<T>(name: string, defaultValue: T): T {
+  _decode_field<T>(name: string): T {
     // "name":value,
     const obj = this.currentObj;
-    if (!obj.has(name)) { return defaultValue; }
+    if (!obj.has(name)) { return defaultValue<T>(); }
     this.pushVal(obj.get(name)!);
     const res = this.decode<T>();
     this.popVal();

--- a/json/assembly/deserializer.ts
+++ b/json/assembly/deserializer.ts
@@ -33,7 +33,7 @@ export class ValueDeserializer extends Deserializer<JSON.Value>{
     return (<JSON.Arr>this.currentVal);
   }
 
-  _decode_field<T>(name: string): T {
+  decode_field<T>(name: string): T {
     // "name":value,
     const obj = this.currentObj;
     if (!obj.has(name)) { return defaultValue<T>(); }

--- a/transform/src/methodInjector.ts
+++ b/transform/src/methodInjector.ts
@@ -26,8 +26,7 @@ export class MethodInjector extends BaseVisitor {
     
     this.encodeStmts.push(`encoder.encode_field<${_type}>("${name}", this.${name})`);
     
-    let defaultValue: string = node.initializer ? `, ${toString(node.initializer)}`: "";
-    this.decodeStmts.push(`this.${name} = decoder.decode_field<${_type}>("${name}"${defaultValue})`);
+    this.decodeStmts.push(`this.${name} = decoder.decode_field<${_type}>("${name}")`);
   }
 
   visitClassDeclaration(node: ClassDeclaration): void {


### PR DESCRIPTION
Until now, the deserializers would take a "defaultValue" as a parameter in the decode_field method. Such defaultValue would be the one used in case the `field` was not found in the encoded structure. 

This was useful only in JSON, for which I think it is better to remove it as a mandatory parameter, and just use it if necessary.